### PR TITLE
Fix GPL-3.0 license name

### DIFF
--- a/recipes-android/udev-droid-system/udev-droid-system_1.0.bb
+++ b/recipes-android/udev-droid-system/udev-droid-system_1.0.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Creates the /dev/block/platform/msm_sdcc.1/by-name/ partitions as expected by some Android binaries."
 LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
 
 SRC_URI = "file://998-droid-system.rules"
 


### PR DESCRIPTION
Also affected are `skipjack` and `narwhal`. I don't know why the build sometimes works sometimes doesn't, but we should fix it either way.